### PR TITLE
Escaping Slashes in description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ralfeggert/zend-expressive-tutorial",
-    "description": "Zend\Expressive tutorial based on the Zend\Expressive skeleton",
+    "description": "Zend\\Expressive tutorial based on the Zend\\Expressive skeleton",
     "type": "project",
     "homepage": "https://github.com/ralfeggert/zend-expressive-tutorial",
     "license": "BSD-3-CLAUSE",


### PR DESCRIPTION
I get a composer error:
[Seld\JsonLint\ParsingException]
"./composer.json" does not contain valid JSON
Parse error on line 3:
...    "description": "Zend\Expressive tut
---------------------^
Invalid string, it appears you have an unescaped backslash at: \E
